### PR TITLE
Fix: autolinks

### DIFF
--- a/NeoMarkdigXaml/Renderers/XamlInlineRenderer.cs
+++ b/NeoMarkdigXaml/Renderers/XamlInlineRenderer.cs
@@ -42,7 +42,7 @@ namespace Neo.Markdig.Xaml.Renderers.Inlines
 				url = "mailto:" + url;
 
 			LinkInlineRenderer.WriteStartHyperlink(renderer, url, title);
-			renderer.WriteText(title);
+			renderer.WriteItems(title);
 			LinkInlineRenderer.WriteEndHyperlink(renderer);
 		} // proc Write
 	} // class AutolinkInlineRenderer

--- a/NeoMarkdigXaml/Renderers/XamlMarkdownWriter.cs
+++ b/NeoMarkdigXaml/Renderers/XamlMarkdownWriter.cs
@@ -483,6 +483,17 @@ namespace Neo.Markdig.Xaml.Renderers
             WriteEndItems();
 		} // proc WriteItems
 
+		/// <summary>Write text as content in the current type.</summary>
+		/// <param name="text"></param>
+		/// <param name="preserveSpaces"></param>
+		public void WriteItems(string text, bool preserveSpaces = false)
+		{
+			var member = xamlTypes.Peek().ContentProperty ?? throw new ArgumentNullException(nameof(XamlType.ContentProperty));
+			WriteStartItems(member, preserveSpaces);
+			WriteText(text);
+			WriteEndItems();
+		}
+
 		private bool IsPendingText => textBuffer.Length > 0;
 
 		#endregion

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var xaml = MarkdownXaml.ToXaml(content,
 Supports standard features from Markdig.
 
 Additionally, the following extensions are supported:
-- AutoLinks
+- AutoLinks (such as <https://github.com>)
 - Tables
 - Extra emphasis
 


### PR DESCRIPTION
Autolinks (such as <http://my_url>) were crashing the lib. I'm not sure about the code but it sure does fix the problem.

NB:  adding an `.editorconfig` could be nice, using hard tabs is not the default in C#.